### PR TITLE
chore: change coverage dir

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@
      - pip install pytest pytest-cov codecov
      - pip install .
   script:
-    - pytest --cov=./
+    - pytest --cov=habits tests/
   after_success:
     - codecov


### PR DESCRIPTION
This PR adjusts the pytest command so that the coverage report only includes the `habits` python package.