### PR TITLE
chore: limit codecov PR comments for when coverage changes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+        require_changes: yes


### PR DESCRIPTION
This PR adds `codecov.yml` to configure the coverage reporting CI system Codecov. Now, it will only leave a comment with coverage details if the coverage actually changes.