### PR TITLE
fix: score only last 7 days of sleep

### DIFF
--- a/habits/person.py
+++ b/habits/person.py
@@ -32,7 +32,7 @@ class Person(object):
 
         hours_score = 0
         wake_score = 0
-        for sleep in self.sleep_history:
+        for sleep in self.sleep_history[-7:]:
             if sleep.end - sleep.start >= self.sleep_hours_goal:
                 hours_score += 1
             if sleep.end.time() <= self.sleep_wake_goal:

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, time
 def person_with_sleep_history():
     p = Person('Glen')
     p.sleep_history.extend([
+        Sleep(datetime(2018, 2, 18, 21, 0), datetime(2018, 2, 20, 5, 0)),
         Sleep(datetime(2018, 2, 19, 22, 0), datetime(2018, 2, 20, 5, 45)),
         Sleep(datetime(2018, 2, 20, 22, 0), datetime(2018, 2, 21, 5, 30)),
         Sleep(datetime(2018, 2, 21, 23, 0), datetime(2018, 2, 22, 5, 0)),


### PR DESCRIPTION
This PR fixes a bug where scoring sleep would look at every day in the sleep history instead of just the last 7 days.

It adds an 8th day to the sleep history so that we can test that only the latest 7 days are scored.