### PR TITLE
chore: hide Codecov comments on no coverage change

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
 comment:
-        require_changes: yes
+    layout: "diff, flags, files, footer"
+    behavior: default
+    require_changes: yes


### PR DESCRIPTION
This PR updates `codecov.yml` to make Codecov not post PR comments if there is no coverage change.

I already had this configured but I think it might be ignoring the config file because I didn't list `layout` and `behavior` options.